### PR TITLE
Un-exclude java/lang/String/UnicodeCasingTest.java from problem list

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -26,7 +26,6 @@
 
 # jdk_lang
 
-java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
 java/lang/Class/GetModuleTest.java	https://github.com/eclipse/openj9/issues/3040	generic-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse/openj9/issues/5225	generic-all


### PR DESCRIPTION
PR to remove the UnicodeCasingTest from the problem list. Original issue has been patched for JDK11 on the specific linux distro https://github.com/eclipse/openj9/pull/4688.

[UnicodeCasingTest-jdk11-openj9-results.txt](https://github.com/M-Davies/openjdk-tests/files/3407160/UnicodeCasingTest-jdk11-openj9-results.txt)

Also tested on openjdk_x86-64_windows and openjdk_x86-64_linux, passing in both instances