### PR TITLE
Un-excluded java/lang/String/UnicodeCasingTest.java from problem list

### DIFF
--- a/openjdk/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/ProblemList_openjdk12-openj9.txt
@@ -56,7 +56,6 @@ java/lang/String/CaseInsensitiveComparator.java	https://github.com/AdoptOpenJDK/
 java/lang/String/CompactString/IndexOf.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/String/EqualsIgnoreCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
 java/lang/String/concat/WithSecurityManager.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all


### PR DESCRIPTION
PR to remove the UnicodeCasingTest from the problem list. Original issue has been patched for JDK12 on the specific linux distro eclipse/openj9#4688.

https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder_Advanced/44/consoleText

Also tested on openjdk_x86-64_windows and openjdk_x86-64_linux, passing in both instances